### PR TITLE
add retries, error handling, and session expired

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-src
 tests
 webpack.config.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,9 @@
     "extends": "standard",
     "plugins": [
         "standard"
-    ]
+    ],
+    "env": {
+        "mocha": true,
+        "es6": true
+    }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 dist
 lib
 src/meta-version.js
+.idea
+*.iml
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ All methods to retrive data from the API is attached to the Session object.
 - update(resource,data) -> Promise
 - remove(resource) -> Promise
 - clearCache()
+- onError(callback(error))
+- onSessionExpired(callback())
+- setToken()
 
 
 ### Create a session
@@ -133,6 +136,45 @@ Errors returned from the SDK methods is of the same structure as error responses
     endpoint: 'https://api.six.se/v2/'
   }
 }
+```
+
+#### onError
+All errors are sent to the onError function
+
+```javascript
+// register an error handler with the session
+session.onError(function logErrors (error) {
+  // this callback can be called more then once
+})
+```
+
+#### onSessionExpired and setToken
+When the API indicates that the token has expired onSessionExpired callback will be called.
+There are two ways of setting a new token.
+
+**Return the new token in the onSessionExpired callback**
+```javascript
+session.onSessionExpired(function refreshToken() {
+  // This callback will be called for every request that receives session expired
+  return fetchNewToken()
+})
+```
+
+**Set the new token with setToken()**
+```javascript
+session.onSessionExpired(function refreshToken() {
+  // This callback will be called for every request that receives session expired
+  session.setToken(fetchNewToken())
+})
+```
+
+**Refresh token every hour**
+```javascript
+// You can set a new token any time
+var ONE_HOUR = 1000 * 60 * 60
+setInterval(function updateToken() {
+  session.setToken(fetchNewToken())
+}, ONE_HOUR)
 ```
 
 ### Caching

--- a/bin/create-meta-version.js
+++ b/bin/create-meta-version.js
@@ -11,12 +11,12 @@ const git = function (cmd, cb) {
 }
 
 // read package.json
-const package = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'))
+const packageObject = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'))
 
 const versionInfo = {
-  version: package.version,
+  version: packageObject.version,
   git: {
-    //tag: git('describe --always --tag --abbrev=0'),
+    // tag: git('describe --always --tag --abbrev=0'),
     short: git('rev-parse --short HEAD'),
     long: git('rev-parse HEAD'),
     branch: git('rev-parse --abbrev-ref HEAD')
@@ -24,8 +24,8 @@ const versionInfo = {
 }
 
 // convert to JSON
-const json = JSON.stringify(versionInfo,null,2)
+const json = JSON.stringify(versionInfo, null, 2)
 
 // write file
-console.log('writing '+target)
-fs.writeFileSync(target,'export default '+json)
+console.log('writing  ' + target)
+fs.writeFileSync(target, 'export default ' + json)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "^1.10.3",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-react": "^3.14.0",
-    "eslint-plugin-standard": "^1.3.1",
+    "eslint-plugin-standard": "^1.3.2",
     "jsdom": "^8.0.2",
     "mocha": "^2.4.5",
     "mocha-jsdom": "^1.0.0",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -15,11 +15,26 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
 
     req.onerror = (event) => {
       reject({
-        code: "AJAX_ERROR",
-        title: "Request to endpoint failed",
-        description: "The request failed. Check that the endpoint is valid?",
+        code: 'AJAX_ERROR',
+        title: 'Request to endpoint failed',
+        description: 'The request failed. Check that the endpoint is valid?',
         details: {
-          endpoint: endpoint
+          endpoint,
+          url,
+          status: req.status
+        }
+      })
+    }
+
+    req.ontimeout = (event) => {
+      reject({
+        code: 'AJAX_ERROR',
+        title: 'Request to endpoint timed out',
+        description: 'The request timed out. Check that the endpoint is valid?',
+        details: {
+          endpoint,
+          url,
+          status: req.status
         }
       })
     }
@@ -32,7 +47,7 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
       if (req.status >= 200 && req.status < 400) {
         // The 204 response MUST NOT include a message-body ...
         if (req.status === 204) {
-            resolve(null)
+          resolve(null)
         }
 
         try {
@@ -43,12 +58,14 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
           }
         } catch (e) {
           reject({
-            code: "INVALID_RESPONSE",
+            code: 'INVALID_RESPONSE',
             title: "Response isn't valid JSON",
             description: "The response couldn't be parsed into an Javascript object. Check that the endpoint is valid?",
             details: {
-              endpoint: endpoint,
-              responseText: req.responseText
+              endpoint,
+              url,
+              responseText: req.responseText,
+              status: req.status
             }
           })
         }
@@ -61,12 +78,14 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
           }
         } catch (e) {
           reject({
-            code: "INVALID_RESPONSE",
+            code: 'INVALID_RESPONSE',
             title: "Response isn't valid JSON",
             description: "The response couldn't be parsed into an Javascript object. Check that the endpoint is valid?",
             details: {
-              endpoint: endpoint,
-              responseText: req.responseText
+              endpoint,
+              url,
+              responseText: req.responseText,
+              status: req.status
             }
           })
         }
@@ -91,4 +110,10 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
       req.send()
     }
   })
+}
+
+export const createFetch = function createFetch (token, url, endpoint, context, {method, body} = {method: 'GET', body: null}) {
+  return function savedFetch () {
+    return fetch(token, url, endpoint, context, {method, body})
+  }
 }

--- a/tests/session.js
+++ b/tests/session.js
@@ -13,6 +13,7 @@ describe('subscribe(resource,[callback])',() => {
   const TOKEN = 'fake-token'
   const response = {id: '848', url: '/listing/848'}
   let session = null
+  let clock
 
   // restore xhr
   const xhr = global.XMLHttpRequest
@@ -62,6 +63,22 @@ describe('subscribe(resource,[callback])',() => {
     XMLHttpRequest.respondWithError({})
   })
 
+  it('should propagate errors to session error handlers',(done) => {
+    const errorSpy = sinon.spy((error) => {
+      expect(error).to.exist
+      expect(error.code).to.equal('AJAX_ERROR')
+      done()
+    })
+    session.onError(errorSpy)
+    session.subscribe('/listings/848',(err,data) => {
+      expect(data).to.not.exist
+      expect(err).to.exist
+      expect(err.code).to.equal('AJAX_ERROR')
+    })
+
+    XMLHttpRequest.respondWithError({})
+  })
+
   it('refresh', (done) => {
     let calls = 0
     session.subscribe('/listings/848',(err,data) => {
@@ -92,4 +109,125 @@ describe('subscribe(resource,[callback])',() => {
     session.refresh('/listings/848')
   })
 
+  describe('retries', () => {
+    it('should retry on failure',(done) => {
+      global.MAX_RETRIES = 1
+      global.RETRY_START_TIMEOUT = 1
+      global.RETRY_TIMEOUT_INCREMENT = 1
+      const errorSpy = sinon.spy((error) => {
+        expect(error).to.exist
+        expect(error.code).to.equal('AJAX_ERROR')
+      })
+      session.onError(errorSpy)
+      const callback = sinon.spy()
+      session.subscribe('/listings/848', callback)
+
+      XMLHttpRequest.respondWithError({})
+      XMLHttpRequest.respondWith(response)
+
+      setTimeout(() => {
+        // request successful
+        expect(callback.called).to.be.true
+        expect(callback.calledTwice).to.be.true
+        expect(errorSpy.calledOnce).to.be.true
+        done()
+      }, 10)
+    })
+
+    it('should not retry on user error',(done) => {
+      global.MAX_RETRIES = 1
+      global.RETRY_START_TIMEOUT = 1
+      global.RETRY_TIMEOUT_INCREMENT = 1
+      const errorSpy = sinon.spy((error) => {
+        expect(error).to.exist
+        expect(error.code).to.equal('AJAX_ERROR')
+      })
+      session.onError(errorSpy)
+      const callback = sinon.spy()
+      session.subscribe('/listings/848', callback)
+
+      // bad request
+      XMLHttpRequest.respondWithError({}, 400)
+
+      // this request should not be executed
+      XMLHttpRequest.respondWith(response)
+
+      setTimeout(() => {
+        // request failed
+        expect(callback.calledOnce).to.be.true
+      }, 2)
+      setTimeout(() => {
+        // no new request
+        expect(callback.calledTwice).to.be.false
+        expect(errorSpy.calledOnce).to.be.true
+        done()
+      }, 10)
+    })
+  })
+
+  describe('onSessionExpired', () => {
+    it('should call onSessionExpired on 401 errors',(done) => {
+      const sessionExpiredSpy = sinon.spy(function sessionExpiredSpy () {
+        return 'new-token'
+      })
+      session.onSessionExpired(sessionExpiredSpy)
+      session.subscribe('/listings/848',(err,data) => {
+        expect(data).to.not.exist
+        expect(err).to.exist
+        expect(err.code).to.equal('AJAX_ERROR')
+      })
+
+      XMLHttpRequest.respondWithError({}, 401)
+
+      setTimeout(() => {
+        expect(sessionExpiredSpy.called).to.be.true
+        expect(session._internal.getToken()).to.equal('new-token')
+        done()
+      }, 0)
+    })
+
+    it('should set the token in all instances',(done) => {
+      const sessionExpiredSpy = sinon.spy(function sessionExpiredSpy () {
+        return 'new-token'
+      })
+      session.onSessionExpired(sessionExpiredSpy)
+      const newContext = session.withContext({})
+      session.subscribe('/listings/848',(err,data) => {
+        expect(data).to.not.exist
+        expect(err).to.exist
+        expect(err.code).to.equal('AJAX_ERROR')
+      })
+
+      XMLHttpRequest.respondWithError({}, 401)
+
+      setTimeout(() => {
+        expect(sessionExpiredSpy.called).to.be.true
+        expect(session._internal.getToken()).to.equal('new-token')
+        expect(newContext._internal.getToken()).to.equal('new-token')
+        done()
+      }, 0)
+    })
+
+    it('should be possible to manually set the token',(done) => {
+      const sessionExpiredSpy = sinon.spy(function sessionExpiredSpy () {
+        session.setToken('new-token')
+      })
+      session.onSessionExpired(sessionExpiredSpy)
+      const newContext = session.withContext({})
+      session.subscribe('/listings/848',(err,data) => {
+        expect(data).to.not.exist
+        expect(err).to.exist
+        expect(err.code).to.equal('AJAX_ERROR')
+      })
+
+      XMLHttpRequest.respondWithError({}, 401)
+
+      setTimeout(() => {
+        expect(sessionExpiredSpy.called).to.be.true
+        expect(session._internal.getToken()).to.equal('new-token')
+        expect(newContext._internal.getToken()).to.equal('new-token')
+        done()
+      }, 0)
+    })
+  })
 })


### PR DESCRIPTION
Three new functions on the session object to handle expired session tokens
and errors. setToken will update the token, onSessionExpired will be
called when the api indicates indicates an expired session.
onError will be called on all errors including sessionExpired.

The retry functionality implemented will retry on requests that failed due
to transport errors or server errors (5xx). The retries are less frequent
if the server continues to answer with errors. The retries will stop after
a 100 tries.