### PR TITLE
add retries, error and session-expired subscriptions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-src
 tests
 webpack.config.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,9 @@
     "extends": "standard",
     "plugins": [
         "standard"
-    ]
+    ],
+    "env": {
+        "mocha": true,
+        "es6": true
+    }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 dist
 lib
 src/meta-version.js
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ All methods to retrive data from the API is attached to the Session object.
 - update(resource,data) -> Promise
 - remove(resource) -> Promise
 - clearCache()
+- setToken()
 
 
 ### Create a session
@@ -133,6 +134,38 @@ Errors returned from the SDK methods is of the same structure as error responses
     endpoint: 'https://api.six.se/v2/'
   }
 }
+```
+
+#### error
+All errors are sent to a 'error' subscription.
+
+```javascript
+// register an error handler with the session
+session.subscribe('error', function logErrors (error) {
+  // this callback can be called more then once
+})
+```
+
+#### session-expired and setToken
+To listen to when the session has expired the 'session-expired' resource can be subscribed to.
+The resource will be called when the api responds with a access denied.
+It is then possible to set a new token with the setToken method
+
+**Subscribe to session-expired and set a new token**
+```javascript
+session.subscribe('session-expired', function refreshToken(error, data) {
+  // This callback will be called for every request that receives session expired
+  session.setToken(getNewTokenFromMyBackend())
+})
+```
+
+**Refresh token every hour**
+```javascript
+// You can set a new token any time
+var ONE_HOUR = 1000 * 60 * 60
+setInterval(function updateToken() {
+  session.setToken(fetchNewToken())
+}, ONE_HOUR)
 ```
 
 ### Caching

--- a/bin/create-meta-version.js
+++ b/bin/create-meta-version.js
@@ -11,12 +11,12 @@ const git = function (cmd, cb) {
 }
 
 // read package.json
-const package = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'))
+const packageObject = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'))
 
 const versionInfo = {
-  version: package.version,
+  version: packageObject.version,
   git: {
-    //tag: git('describe --always --tag --abbrev=0'),
+    // tag: git('describe --always --tag --abbrev=0'),
     short: git('rev-parse --short HEAD'),
     long: git('rev-parse HEAD'),
     branch: git('rev-parse --abbrev-ref HEAD')
@@ -24,8 +24,8 @@ const versionInfo = {
 }
 
 // convert to JSON
-const json = JSON.stringify(versionInfo,null,2)
+const json = JSON.stringify(versionInfo, null, 2)
 
 // write file
-console.log('writing '+target)
-fs.writeFileSync(target,'export default '+json)
+console.log('writing  ' + target)
+fs.writeFileSync(target, 'export default ' + json)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "^1.10.3",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-react": "^3.14.0",
-    "eslint-plugin-standard": "^1.3.1",
+    "eslint-plugin-standard": "^1.3.2",
     "jsdom": "^8.0.2",
     "mocha": "^2.4.5",
     "mocha-jsdom": "^1.0.0",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -15,11 +15,26 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
 
     req.onerror = (event) => {
       reject({
-        code: "AJAX_ERROR",
-        title: "Request to endpoint failed",
-        description: "The request failed. Check that the endpoint is valid?",
+        code: 'AJAX_ERROR',
+        title: 'Request to endpoint failed',
+        description: 'The request failed. Check that the endpoint is valid?',
         details: {
-          endpoint: endpoint
+          endpoint,
+          url,
+          status: req.status
+        }
+      })
+    }
+
+    req.ontimeout = (event) => {
+      reject({
+        code: 'AJAX_ERROR',
+        title: 'Request to endpoint timed out',
+        description: 'The request timed out. Check that the endpoint is valid?',
+        details: {
+          endpoint,
+          url,
+          status: req.status
         }
       })
     }
@@ -32,7 +47,7 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
       if (req.status >= 200 && req.status < 400) {
         // The 204 response MUST NOT include a message-body ...
         if (req.status === 204) {
-            resolve(null)
+          resolve(null)
         }
 
         try {
@@ -43,12 +58,14 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
           }
         } catch (e) {
           reject({
-            code: "INVALID_RESPONSE",
+            code: 'INVALID_RESPONSE',
             title: "Response isn't valid JSON",
             description: "The response couldn't be parsed into an Javascript object. Check that the endpoint is valid?",
             details: {
-              endpoint: endpoint,
-              responseText: req.responseText
+              endpoint,
+              url,
+              responseText: req.responseText,
+              status: req.status
             }
           })
         }
@@ -61,12 +78,14 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
           }
         } catch (e) {
           reject({
-            code: "INVALID_RESPONSE",
+            code: 'INVALID_RESPONSE',
             title: "Response isn't valid JSON",
             description: "The response couldn't be parsed into an Javascript object. Check that the endpoint is valid?",
             details: {
-              endpoint: endpoint,
-              responseText: req.responseText
+              endpoint,
+              url,
+              responseText: req.responseText,
+              status: req.status
             }
           })
         }
@@ -91,4 +110,10 @@ export const fetch = function fetch (token, url, endpoint, context, {method, bod
       req.send()
     }
   })
+}
+
+export const createFetch = function createFetch (token, url, endpoint, context, {method, body} = {method: 'GET', body: null}) {
+  return function savedFetch () {
+    return fetch(token, url, endpoint, context, {method, body})
+  }
 }

--- a/src/session.js
+++ b/src/session.js
@@ -1,41 +1,71 @@
-import {fetch} from './fetch'
+import {createFetch} from './fetch'
 import VersionInfo from './meta-version'
+
+const MAX_RETRIES = 100
+const MAX_RETRY_TIMEOUT = 900000// 15 minutes
+const RETRY_START_TIMEOUT = 5000
+const RETRY_TIMEOUT_INCREMENT = 25000
+
+const retry = function retry (fetchFunc, failFunc) {
+  let retryTimeout = global.RETRY_START_TIMEOUT || RETRY_START_TIMEOUT
+  let retries = 0
+  return new Promise(function (resolve, reject) {
+    function doRetry (err) {
+      const status = err.details.status
+      // status 0 should be transport errors and 5xx server errors
+      if ((status === 0 || (status >= 500 && status < 600)) && retries < (global.MAX_RETRIES || MAX_RETRIES)) {
+        failFunc(err)
+        setTimeout(() => {
+          retries++
+          if (retryTimeout < (global.MAX_RETRY_TIMEOUT || MAX_RETRY_TIMEOUT)) {
+            retryTimeout = retryTimeout + (global.RETRY_TIMEOUT_INCREMENT || RETRY_TIMEOUT_INCREMENT)
+          }
+          fetchFunc().then(resolve).catch(doRetry)
+        }, retryTimeout)
+      } else {
+        reject(err)
+      }
+    }
+    fetchFunc().then(resolve).catch(doRetry)
+  })
+}
 
 const deepMerge = function deepMerge (target, source) {
   if (!target) return source
   if (!source) return target
 
   for (var prop in source) {
-      if (source.hasOwnProperty(prop)) {
-          if (Array.isArray(source[prop])) {
-              target[prop] = source[prop]
-          } else if (target[prop] && typeof source[prop] === 'object') {
-              deepMerge(target[prop], source[prop])
-          } else {
-              target[prop] = source[prop]
-          }
+    if (source.hasOwnProperty(prop)) {
+      if (Array.isArray(source[prop])) {
+        target[prop] = source[prop]
+      } else if (target[prop] && typeof source[prop] === 'object') {
+        deepMerge(target[prop], source[prop])
+      } else {
+        target[prop] = source[prop]
       }
+    }
   }
   return target
 }
 
-const mergeIntoArray = function mergeIntoArray (arr,item) {
+const mergeIntoArray = function mergeIntoArray (arr, item) {
   if (!arr) return [item]
   let i = arr.indexOf(item)
-  if (i == -1) arr.push(item)
+  if (i === -1) arr.push(item)
   return arr
 }
 
-const nextId = function() {
+const nextId = (function generateNextId () {
   let id = 0
-  return function() {
+  return function incrementId () {
     id += 1
     return id
   }
-}()
+}())
 
 export default function (token, endpoint) {
-  //TODO: can we use Map?
+  let currentToken = token
+  // TODO: can we use Map?
   const subscriptions = {}
   const resourceToSubscription = {}
 
@@ -50,12 +80,12 @@ export default function (token, endpoint) {
       delete subscriptions[id]
 
       // remove resource -> subscription mapping
-      resourceToSubscription[subscription.resource] = resourceToSubscription[subscription.resource].filter(s => !(s.id == id))
+      resourceToSubscription[subscription.resource] = resourceToSubscription[subscription.resource].filter(s => !(s.id === id))
     }
   }
 
   // merges new data into the cache
-  const merge = function(resource,data) {
+  const merge = function merge (resource, data) {
     let cached = data
 
     // handle paginated data
@@ -63,18 +93,18 @@ export default function (token, endpoint) {
       // merge items into entityCache
       data.items = data.items.map(item => {
         if (item.url) {
-          item = deepMerge(entityCache[item.url],item)
+          item = deepMerge(entityCache[item.url], item)
           entityCache[item.url] = item
-          entityToResource[item.url] = mergeIntoArray(entityToResource[item.url],resource)
+          entityToResource[item.url] = mergeIntoArray(entityToResource[item.url], resource)
         }
         return item
       })
     } else {
       // merge into entityCache
       if (data && data.url) {
-        cached = deepMerge(entityCache[data.url],data)
+        cached = deepMerge(entityCache[data.url], data)
         entityCache[data.url] = cached
-        entityToResource[data.url] = mergeIntoArray(entityToResource[data.url],resource)
+        entityToResource[data.url] = mergeIntoArray(entityToResource[data.url], resource)
       }
 
       // TODO: below must be done also for items in paginated responses
@@ -87,7 +117,7 @@ export default function (token, endpoint) {
     }
 
     // merge into resourceCache
-    cached = deepMerge(resourceCache[resource],cached)
+    cached = deepMerge(resourceCache[resource], cached)
     resourceCache[resource] = cached
 
     return cached
@@ -95,7 +125,7 @@ export default function (token, endpoint) {
 
   // merges a cached domain object with the rest of the domain
   // i.e resolves all relations
-  const mergeRelations = function mergeRelations(obj) {
+  const mergeRelations = function mergeRelations (obj) {
     if (!obj) return obj
 
     // dereference all subresources
@@ -106,7 +136,7 @@ export default function (token, endpoint) {
           if (!cached) {
             entityCache[obj[field].url] = obj[field]
           }
-          obj[field] =  cached || obj[field]
+          obj[field] = cached || obj[field]
 
           // connect subresources back to parent
           if (obj.url) {
@@ -120,15 +150,15 @@ export default function (token, endpoint) {
   }
 
   // domain-specific merge function, handles Bid/Ask syncing etc
-  const mergeDomain = function mergeDomain(obj) {
+  const mergeDomain = function mergeDomain (obj) {
     if (!obj) return obj
 
     // Orderbooks Level 1 Bid/Ask should match Quotes Bid/Ask
-    let listingWithOrderbook = obj.orderbook ? obj: null
+    let listingWithOrderbook = obj.orderbook ? obj : null
 
     // special handling for "naked" orderbooks
-    if (obj.url && obj.url.endsWith("/orderbook")) {
-      let entityUrl = obj.url.substring(0,obj.url.length - "/orderbook".length)
+    if (obj.url && obj.url.endsWith('/orderbook')) {
+      let entityUrl = obj.url.substring(0, obj.url.length - '/orderbook'.length)
       listingWithOrderbook = entityCache[entityUrl]
 
       if (listingWithOrderbook && (!listingWithOrderbook.orderbook)) {
@@ -155,20 +185,51 @@ export default function (token, endpoint) {
       _entityCache: entityCache,
       _resourceCache: resourceCache,
       _entityToResource: entityToResource,
-      _context: {sdk: VersionInfo.version },
+      _context: { sdk: VersionInfo.version },
 
-      publish: function(resource,data,err) {
+      getToken: function getToken () {
+        return currentToken
+      },
+
+      publishError: function publishError (resource, data, err) {
+        // Access denied
+        if (err.details.status === 401) {
+          const sessionExpiredSubscriptions = resourceToSubscription['session-expired']
+          if (sessionExpiredSubscriptions) {
+            const called = Object.create(null)
+            sessionExpiredSubscriptions.forEach(s => {
+              if (!called[s.id]) {
+                s.callback(err, data, s.unsubscribeFn)
+                called[s.id] = true
+              }
+            })
+          }
+        }
+        const errorSubscriptions = resourceToSubscription['error']
+        if (errorSubscriptions) {
+          const called = Object.create(null)
+          errorSubscriptions.forEach(s => {
+            if (!called[s.id]) {
+              setTimeout(() => { s.callback(err, data, s.unsubscribeFn) })
+              called[s.id] = true
+            }
+          })
+        }
+        let subscriptions = resourceToSubscription[resource]
+        if (subscriptions) {
+          subscriptions.forEach(s => s.callback(err, data, s.unsubscribeFn))
+        }
+      },
+
+      publish: function publish (resource, data, err) {
         // on errors, notify all subscriptions *only* for original resource
         if (err) {
-          let subscriptions = resourceToSubscription[resource]
-          if (subscriptions) {
-            subscriptions.forEach(s => s.callback(err,data,s.unsubscribeFn))
-          }
+          this.publishError(resource, data, err)
           return
         }
 
-        //merge data into cache
-        data = merge(resource,data)
+        // merge data into cache
+        data = merge(resource, data)
 
         // Optimize so we don't call callbacks more than once/publish.
         // Not strictly necessary, but helps in tests and debugging
@@ -182,7 +243,7 @@ export default function (token, endpoint) {
         if (subscriptions) {
           subscriptions.forEach(subscription => {
             if (!called[subscription.id]) {
-              subscription.callback(err,data,subscription.unsubscribeFn)
+              subscription.callback(err, data, subscription.unsubscribeFn)
               called[subscription.id] = true
             }
           })
@@ -210,7 +271,7 @@ export default function (token, endpoint) {
                 if (subscriptions) {
                   subscriptions.forEach(s => {
                     if (!called[s.id]) {
-                      s.callback(err,response,s.unsubscribeFn)
+                      s.callback(err, response, s.unsubscribeFn)
                       called[s.id] = true
                     }
                   })
@@ -230,7 +291,7 @@ export default function (token, endpoint) {
                     if (subscriptions) {
                       subscriptions.forEach(subscription => {
                         if (!called[subscription.id]) {
-                          subscription.callback(err,resourceCache[resource],subscription.unsubscribeFn)
+                          subscription.callback(err, resourceCache[resource], subscription.unsubscribeFn)
                           called[subscription.id] = true
                         }
                       })
@@ -239,7 +300,6 @@ export default function (token, endpoint) {
                 }
               }
             })
-
           }
         }
 
@@ -257,7 +317,7 @@ export default function (token, endpoint) {
                 if (subscriptions) {
                   subscriptions.forEach(s => {
                     if (!called[s.id]) {
-                      s.callback(err,response,s.unsubscribeFn)
+                      s.callback(err, response, s.unsubscribeFn)
                       called[s.id] = true
                     }
                   })
@@ -268,14 +328,17 @@ export default function (token, endpoint) {
         }
       },
 
-      fetch: function(resource,callback) {
+      fetch: function fetch (resource, callback) {
         this.debug && console.log('fetch', resource)
-        return fetch(token, resource, endpoint, this._context)
-      },
+        const errFunc = (err) => { this._internal.publishError(resource, null, err) }
+        const promise = retry(createFetch(currentToken, resource, endpoint, this._context), errFunc)
+        promise.catch(errFunc)
+        return promise
+      }
     },
 
     subscribe: function subscribe (resource, callback) {
-      this.debug && console.log('subscribe', token, resource, endpoint)
+      this.debug && console.log('subscribe', currentToken, resource, endpoint)
       const sub = {id: nextId(), resource, callback}
 
       // create an Fn to unsubscribe
@@ -287,18 +350,18 @@ export default function (token, endpoint) {
       // resource -> subscription (exact mapping)
       resourceToSubscription[resource] = resourceToSubscription[resource] || []
       resourceToSubscription[resource].push(sub)
-      //console.log('resourceToSubscription',resourceToSubscription)
+      // console.log('resourceToSubscription',resourceToSubscription)
 
       // check cache for this resource
       if (resourceCache[resource]) {
-        //console.log("resource found in cache, notify direct")
-        callback(null,resourceCache[resource],sub.unsubscribeFn)
+        // console.log("resource found in cache, notify direct")
+        callback(null, resourceCache[resource], sub.unsubscribeFn)
         return sub.unsubscribeFn
       }
 
       // if not found in cache, we call refresh to fetch from the API
       // (only for API resources, i.e starting with a /)
-      if (resource[0] == '/') {
+      if (resource[0] === '/') {
         this.refresh(resource)
       }
 
@@ -308,46 +371,54 @@ export default function (token, endpoint) {
 
     refresh: function refresh (resource) {
       this.debug && console.log('refresh', resource)
-      fetch(token, resource, endpoint, this._internal._context)
-      .then((response) => setTimeout(() => this._internal.publish(resource,response,null), 0))
-      .catch((err) => setTimeout(() => this._internal.publish(resource,null,err), 0))
+      const errFunc = (err) => { this._internal.publishError(resource, null, err) }
+      retry(createFetch(currentToken, resource, endpoint, this._internal._context), errFunc)
+      .then((response) => setTimeout(() => this._internal.publish(resource, response, null), 0))
+      .catch(errFunc)
     },
 
-    create: function refresh (resource,content) {
+    create: function create (resource, content) {
       this.debug && console.log('refresh', resource, content)
-      let promise = fetch(token, resource, endpoint, this._internal._context, {method: 'POST', body: content})
+      const errFunc = (err) => { this._internal.publishError(resource, null, err) }
+      let promise = retry(createFetch(currentToken, resource, endpoint, this._internal._context, {method: 'POST', body: content}), errFunc)
       promise.then((response) => setTimeout(() => {
         if (response && response.url) {
-          this._internal.publish(response.url,response,null)
+          this._internal.publish(response.url, response, null)
         }
       }
       , 0))
+      promise.catch(errFunc)
       return promise
     },
 
-    update: function refresh (resource,content) {
+    update: function update (resource, content) {
       this.debug && console.log('update', resource, content)
-      let promise = fetch(token, resource, endpoint, this._internal._context, {method: 'PUT', body: content})
-      promise.then((response) => setTimeout(() => this._internal.publish(resource,response,null), 0))
+      const errFunc = (err) => { this._internal.publishError(resource, null, err) }
+      let promise = retry(createFetch(currentToken, resource, endpoint, this._internal._context, {method: 'PUT', body: content}), errFunc)
+      promise.then((response) => setTimeout(() => this._internal.publish(resource, response, null), 0))
+      promise.catch(errFunc)
       return promise
     },
 
-    remove: function refresh (resource) {
+    remove: function remove (resource) {
       this.debug && console.log('remove', resource)
-      let promise = fetch(token, resource, endpoint, this._internal._context, {method: 'DELETE', body: null})
+      const errFunc = (err) => { this._internal.publishError(resource, null, err) }
+      let promise = retry(createFetch(currentToken, resource, endpoint, this._internal._context, {method: 'DELETE', body: null}), errFunc)
 
       promise.then((response) => setTimeout(() => {
         delete resourceCache[resource]
-        this._internal.publish(resource,null,null)
+        this._internal.publish(resource, null, null)
       }, 0))
+      promise.catch(errFunc)
 
       return promise
     },
 
     clearCache: function clearCache () {
-      for (var prop in entityCache)       { if (entityCache.hasOwnProperty(prop))       { delete entityCache[prop] } }
-      for (var prop in resourceCache)     { if (resourceCache.hasOwnProperty(prop))     { delete resourceCache[prop] } }
-      for (var prop in entityToResource)  { if (entityToResource.hasOwnProperty(prop))  { delete entityToResource[prop] } }
+      /* eslint no-multi-spaces: 0 */
+      for (let prop in entityCache)       { if (entityCache.hasOwnProperty(prop))       { delete entityCache[prop] } }
+      for (let prop in resourceCache)     { if (resourceCache.hasOwnProperty(prop))     { delete resourceCache[prop] } }
+      for (let prop in entityToResource)  { if (entityToResource.hasOwnProperty(prop))  { delete entityToResource[prop] } }
     },
 
     withContext: function withContext (context) {
@@ -355,6 +426,10 @@ export default function (token, endpoint) {
       newSession._internal = Object.create(this._internal)
       newSession._internal._context = Object.assign({}, this._internal._context, context)
       return newSession
+    },
+
+    setToken: function setToken (newToken) {
+      currentToken = newToken
     }
   }
 }


### PR DESCRIPTION
Added retries with backoff functionality on server and transport errors.
The retries will try 100 times with an increasing timeout up to 15
minutes.
Two new subscriptions:
error
This will listen to all errors that occurs in the sdk
session-expired
This will listen to session expired and by using setToken it is possible
to update the token.